### PR TITLE
Center footer svg.

### DIFF
--- a/docs/disclose.css
+++ b/docs/disclose.css
@@ -117,7 +117,7 @@ section.dark {
 section.dark svg {
   display: block;
   max-height: 4.5em;
-  margin: 1em auto;
+  margin: 0 auto 1em;
 }
 
 svg.logo {

--- a/docs/disclose.css
+++ b/docs/disclose.css
@@ -118,6 +118,7 @@ section.dark svg {
   display: block;
   margin-bottom: 1em;
   max-height: 4.5em;
+  margin: 0 auto;
 }
 
 svg.logo {

--- a/docs/disclose.css
+++ b/docs/disclose.css
@@ -116,9 +116,8 @@ section.dark {
 
 section.dark svg {
   display: block;
-  margin-bottom: 1em;
   max-height: 4.5em;
-  margin: 0 auto;
+  margin: 1em auto;
 }
 
 svg.logo {


### PR DESCRIPTION
By setting `margin` to `1em auto`, the footer's logo is centered properly.

## Before

![image](https://user-images.githubusercontent.com/18099289/43599518-2bf1d306-9688-11e8-94f9-15c41f3c64d2.png)

## After

![image](https://user-images.githubusercontent.com/18099289/43599496-1931dd2e-9688-11e8-8753-66ec87230b93.png)
