### PR TITLE
Fix markdown lint issues, consistent use of ;, consistent use of policy

### DIFF
--- a/terms/core.md
+++ b/terms/core.md
@@ -1,54 +1,61 @@
-**Introduction**
+# Responsible Disclosure Policy
 
-Security is core to our values, and we value the input of hackers acting in good faith to help us maintain a high standard for the security and privacy for our users. This includes encouraging responsible vulnerability research and disclosure. This policy sets out our definition of good faith in the context of finding and reporting vulnerabilities, as well as what you can expect from us in return. 
+## Introduction
 
-**Expectations**
+Security is core to our values, and we value the input of hackers acting in good faith to help us maintain a high standard for the security and privacy for our users. This includes encouraging responsible vulnerability research and disclosure. This policy sets out our definition of good faith in the context of finding and reporting vulnerabilities, as well as what you can expect from us in return.
+
+## Expectations
 
 When working with us according to this policy, you can expect us to:
+
 - Extend Safe Harbor for your vulnerability research that is related to this policy;
-- Work with you to understand and validate your report, including an initial response to the report within 72 hours of submission; 
+- Work with you to understand and validate your report, including an initial response to the report within 72 hours of submission;
 - Work to remediate discovered vulnerabilities in a timely manner; and
 - Recognize your contribution to improving our security if you are the first to report a unique vulnerability, and your report triggers a code or configuration change.
 
-**Safe Harbor**
+## Safe Harbor
 
 When conducting vulnerability research according to this policy, we consider this research to be:
-- Authorized in accordance with the Computer Fraud and Abuse Act (CFAA) (and/or similar state laws), and we will not initiate or support legal action against you for accidental, good faith violations of this policy; 
-- Exempt from the Digital Millennium Copyright Act (DMCA), and we will not bring a claim against you for circumvention of technology controls; 
-- Exempt from restrictions in our Terms & Conditions that would interfere with conducting security research, and we waive those restrictions on a limited basis for work done under this policy;  
+
+- Authorized in accordance with the Computer Fraud and Abuse Act (CFAA) (and/or similar state laws), and we will not initiate or support legal action against you for accidental, good faith violations of this policy;
+- Exempt from the Digital Millennium Copyright Act (DMCA), and we will not bring a claim against you for circumvention of technology controls;
+- Exempt from restrictions in our Terms & Conditions that would interfere with conducting security research, and we waive those restrictions on a limited basis for work done under this policy; and
 - Lawful, helpful to the overall security of the Internet, and conducted in good faith.
 
 You are expected, as always, to comply with all applicable laws.
 
 If at any time you have concerns or are uncertain whether your security research is consistent with this policy, please submit a report through one of our Official Channels before going any further.
 
-**Ground Rules**
+## Ground Rules
 
 To encourage vulnerability research and to avoid any confusion between good-faith hacking and malicious attack, we ask that you:
-- Play by the rules. This includes following this policy, as well as any other relevant agreements. If there is any inconsistency between this policy and any other relevant terms, the terms of this policy will prevail.
-- Report any vulnerability you’ve discovered promptly.
-- Avoid violating the privacy of others, disrupting our systems, destroying data, and/or harming user experience.
-- Use only the Official Channels to discuss vulnerability information with us.
-- Keep the details of any discovered vulnerabilities confidential until they are fixed, according to the Disclosure Terms in this policy.
-- Perform testing only on in-scope systems, and respect systems and activities which are out-of-scope.
-- If a vulnerability provides unintended access to data: Limit the amount of data you access to the minimum required for effectively demonstrating a Proof of Concept; and cease testing and submit a report immediately if you encounter any user data during testing, such as Personally Identifiable Information (PII), Personal Healthcare Information (PHI), credit card data, or proprietary information.
-- You should only interact with test accounts you own or with explicit permission from the account holder.
-- Do not engage in extortion. 
 
-**Official Channels**
+- Play by the rules. This includes following this policy, as well as any other relevant agreements. If there is any inconsistency between this policy and any other relevant terms, the terms of this policy will prevail;
+- Report any vulnerability you’ve discovered promptly;
+- Avoid violating the privacy of others, disrupting our systems, destroying data, and/or harming user experience;
+- Use only the Official Channels to discuss vulnerability information with us;
+- Keep the details of any discovered vulnerabilities confidential until they are fixed, according to the Disclosure Terms in this policy;
+- Perform testing only on in-scope systems, and respect systems and activities which are out-of-scope;
+- If a vulnerability provides unintended access to data: Limit the amount of data you access to the minimum required for effectively demonstrating a Proof of Concept; and cease testing and submit a report immediately if you encounter any user data during testing, such as Personally Identifiable Information (PII), Personal Healthcare Information (PHI), credit card data, or proprietary information;
+- You should only interact with test accounts you own or with explicit permission from the account holder; and
+- Do not engage in extortion.
+
+## Official Channels
 
 To help us receive vulnerability submissions we use the following official reporting channels:
+
 - $WEBFORM or $PLATFORM_PAGE
 - security@company.com email address; and
 - A squad of carrier pigeons.
 
 If you think you’ve found a vulnerability, please include the following details with your report and be as descriptive as possible:
-- The location and nature of the vulnerability,
-- A detailed description of the steps required to reproduce the vulnerability (screenshots, compressed screen recordings, and proof-of-concept scripts are all helpful), and
+
+- The location and nature of the vulnerability;
+- A detailed description of the steps required to reproduce the vulnerability (screenshots, compressed screen recordings, and proof-of-concept scripts are all helpful); and
 - Your name/handle and a link for recognition.
 
 If you’d like to encrypt the information, please use our PGP key.
 
-[...] 
+[...]
 
-We may modify the terms of this program or terminate this program at any time. We won’t apply any changes we make to these program terms retroactively.
+We may modify the terms of this policy or terminate this policy at any time. We won’t apply any changes we make to these policy terms retroactively.

--- a/terms/core.md
+++ b/terms/core.md
@@ -1,4 +1,4 @@
-# Responsible Disclosure Policy
+# Core Terms
 
 ## Introduction
 
@@ -58,4 +58,4 @@ If you’d like to encrypt the information, please use our PGP key.
 
 [...]
 
-We may modify the terms of this policy or terminate this policy at any time. We won’t apply any changes we make to these policy terms retroactively.
+We may modify the terms of this program or terminate this program at any time. We won’t apply any changes we make to these program terms retroactively.


### PR DESCRIPTION
The major content change that I've made is to the use of program in the final paragraph to be policy.  Policy is what is used in the opening paragraph and so is what is probably intended.

Throughout the document there was mixed use of full stops, commas and semi colons for the end of a list item, I've standardised these to be semi colon.  Likewise there was in some cases the use of and at the end of the second to last list item, and not in others.  I've added and where missing.

I've also run it through a mark down linter and fixed the issues raised.  The most significant change that this resulted in was the addition of a top level header.