### PR TITLE
Add Arduino CVD policy

### DIFF
--- a/bug-bounty-list/bug-bounty-list.json
+++ b/bug-bounty-list/bug-bounty-list.json
@@ -575,9 +575,9 @@
     "submission_url": "security@arduino.cc",
     "launch_date": "",
     "cash_reward": false,
-    "swag": true,
+    "swag": false,
     "hall_of_fame": false,
-    "safe_harbor": ""
+    "safe_harbor": "partial"
   },  
   {
     "program_name": "Ark",

--- a/bug-bounty-list/bug-bounty-list.json
+++ b/bug-bounty-list/bug-bounty-list.json
@@ -570,6 +570,16 @@
     "safe_harbor": ""
   },
   {
+    "program_name": "Arduino",
+    "policy_url": "https://www.arduino.cc/en/Main/Security",
+    "submission_url": "security@arduino.cc",
+    "launch_date": "",
+    "cash_reward": false,
+    "swag": true,
+    "hall_of_fame": false,
+    "safe_harbor": ""
+  },  
+  {
     "program_name": "Ark",
     "policy_url": "https://blog.ark.io/ark-github-development-bounty-113806ae9ffe",
     "submission_url": "security@ark.io",


### PR DESCRIPTION
This commit adds Arduino's CVD policy and submission email to the bug-bounty-list.json file.