### PR TITLE
Remove Cobalt.io hosted listings as none are publicly accessible

### DIFF
--- a/bug-bounty-list/bug-bounty-list.json
+++ b/bug-bounty-list/bug-bounty-list.json
@@ -568,7 +568,7 @@
     "swag": false,
     "hall_of_fame": false,
     "safe_harbor": "partial"
-  },  
+  },
   {
     "program_name": "Ark",
     "policy_url": "https://blog.ark.io/ark-github-development-bounty-113806ae9ffe",
@@ -1180,16 +1180,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "BlockScore",
-    "policy_url": "https://cobalt.io/blockscore",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Blockstack",
     "policy_url": "https://hackerone.com/blockstack",
     "submission_url": "",
@@ -1287,16 +1277,6 @@
     "cash_reward": true,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "BTCC",
-    "policy_url": "https://cobalt.io/btcc",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": false,
     "safe_harbor": ""
   },
   {
@@ -1520,16 +1500,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "ChainPay",
-    "policy_url": "https://cobalt.io/chainpay",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": false,
-    "swag": true,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "ChainRift",
     "policy_url": "https://medium.com/chainrift/chainrift-launches-bug-bounty-program-6255eb2d518d",
     "submission_url": "support@chainrift.com",
@@ -1547,16 +1517,6 @@
     "cash_reward": true,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "ChangeTip",
-    "policy_url": "https://cobalt.io/changetip",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": false,
     "safe_harbor": ""
   },
   {
@@ -1750,29 +1710,9 @@
     "safe_harbor": "full"
   },
   {
-    "program_name": "CoinDaddy",
-    "policy_url": "https://cobalt.io/coindaddy",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": false,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Coinpayments",
     "policy_url": "https://www.coinpayments.net/help-bug-bounty",
     "submission_url": "security@coinpayments.net",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "Coins.ph",
-    "policy_url": "https://cobalt.io/coins-ph",
-    "submission_url": "",
     "launch_date": "",
     "cash_reward": true,
     "swag": false,
@@ -1923,16 +1863,6 @@
     "program_name": "Credit Karma",
     "policy_url": "https://bugcrowd.com/creditkarma",
     "submission_url": "https://bugcrowd.com/creditkarma/report",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "Crix.io",
-    "policy_url": "https://cobalt.io/crixio",
-    "submission_url": "",
     "launch_date": "",
     "cash_reward": true,
     "swag": false,
@@ -2235,16 +2165,6 @@
     "submission_url": "https://dominos.responsibledisclosure.com/hc/en-us/requests/new",
     "launch_date": "",
     "cash_reward": false,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "DoSomething",
-    "policy_url": "https://cobalt.io/dosomething",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": ""
@@ -3410,16 +3330,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "Independent Reserve",
-    "policy_url": "https://cobalt.io/independent-reserve",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Independer",
     "policy_url": "http://www.independer.nl/algemeen/info/responsible-disclosure.aspx",
     "submission_url": "beveiliging@independer.nl",
@@ -4080,31 +3990,11 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "Magnr",
-    "policy_url": "https://cobalt.io/magnr",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Mahara",
     "policy_url": "https://wiki.mahara.org/index.php/Contributors#Security_Researchers",
     "submission_url": "",
     "launch_date": "",
     "cash_reward": false,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "MaiCoin",
-    "policy_url": "https://cobalt.io/maicoin",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": ""
@@ -4315,16 +4205,6 @@
     "submission_url": "https://bugcrowd.com/memotrader/report",
     "launch_date": "",
     "cash_reward": false,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "Mexbt",
-    "policy_url": "https://cobalt.io/mexbt",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": ""
@@ -5270,16 +5150,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "Paysafe",
-    "policy_url": "https://cobalt.io/paysafe",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": false,
-    "swag": false,
-    "hall_of_fame": false,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "PC Extreme",
     "policy_url": "https://www.pcextreme.com/policies/responsible-disclosure",
     "submission_url": "security@pcextreme.nl",
@@ -5630,16 +5500,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "QuickBT",
-    "policy_url": "https://cobalt.io/quickbt",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": false,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Quora",
     "policy_url": "https://hackerone.com/quora",
     "submission_url": "",
@@ -5697,16 +5557,6 @@
     "cash_reward": false,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "Rdbhost_service",
-    "policy_url": "https://cobalt.io/rdbhost-service",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": false,
     "safe_harbor": ""
   },
   {
@@ -6170,16 +6020,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "Sherpany",
-    "policy_url": "https://cobalt.io/sherpany",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Shipt",
     "policy_url": "https://hackerone.com/shipt",
     "submission_url": "",
@@ -6450,16 +6290,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "SpectroCoin",
-    "policy_url": "https://app.cobalt.io/spectrocoin/spectrocoin",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Sphero",
     "policy_url": "https://support.sphero.com/article/5drs94lhk5-vulnerability-disclosure-program",
     "submission_url": "security@sphero.com",
@@ -6628,16 +6458,6 @@
     "swag": false,
     "hall_of_fame": false,
     "safe_harbor": "partial"
-  },
-  {
-    "program_name": "Subledger",
-    "policy_url": "https://cobalt.io/subledger",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
   },
   {
     "program_name": "Summa",
@@ -6878,16 +6698,6 @@
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": "partial"
-  },
-  {
-    "program_name": "TimeTrex",
-    "policy_url": "https://cobalt.io/timetrex",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
-    "safe_harbor": ""
   },
   {
     "program_name": "Tinder",
@@ -7207,16 +7017,6 @@
     "cash_reward": false,
     "swag": false,
     "hall_of_fame": false,
-    "safe_harbor": ""
-  },
-  {
-    "program_name": "Uphold",
-    "policy_url": "https://cobalt.io/uphold",
-    "submission_url": "",
-    "launch_date": "",
-    "cash_reward": true,
-    "swag": false,
-    "hall_of_fame": true,
     "safe_harbor": ""
   },
   {
@@ -7618,7 +7418,7 @@
     "swag": false,
     "hall_of_fame": false,
     "safe_harbor": ""
-  },  
+  },
   {
     "program_name": "Yelp",
     "policy_url": "https://hackerone.com/yelp",


### PR DESCRIPTION
All of the listings previously hosted on Cobalt.io go to a login page without the ability to self-signup (instead taking you to an application to fill out). Since these pages are not accessible, think it's best to remove them.