### PR TITLE
Fixing GitHub's safe harbor status.

### DIFF
--- a/bug-bounty-list/bug-bounty-list.json
+++ b/bug-bounty-list/bug-bounty-list.json
@@ -3137,7 +3137,7 @@
     "bug_bounty": true,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": "partial"
+    "safe_harbor": "full"
   },
   {
     "program_name": "Gitlab",


### PR DESCRIPTION
Hi! Our policies are available at https://bounty.github.com/, including our safe harbor policy (linked from there) which is https://github.com/github/site-policy/blob/master/Policies/github-bug-bounty-program-legal-safe-harbor.md. Our program meets the criteria for full. Thanks!