### PR TITLE
Added Hall of Fame

### DIFF
--- a/bug-bounty-list/bug-bounty-list.json
+++ b/bug-bounty-list/bug-bounty-list.json
@@ -8266,7 +8266,7 @@
     "launch_date": "",
     "bug_bounty": false,
     "swag": false,
-    "hall_of_fame": false,
+    "hall_of_fame": true,
     "safe_harbor": "partial"
   },
   {


### PR DESCRIPTION
Hall of Fame (https://www.visma.com/trust-centre/smb/security-and-privacy/operational/responsible-disclosure/hall-of-fame/) is linked from the Responsible Disclosure page (https://www.visma.com/trust-centre/smb/security-and-privacy/operational/responsible-disclosure/).