### PR TITLE
Update README to fix a broken link and add a new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Driving simplicity, safety, and standardization in vulnerability disclosure.
 
-[disclose.io](https://disclose.io) is a collaborative and vendor-agnostic movement that engagements security researchers, corporate and independant legal experts, and industry leaders from all around the world. 
+[disclose.io](https://disclose.io) is a collaborative and vendor-agnostic movement that engagements security researchers, corporate and independant legal experts, and industry leaders from all around the world.
 
 The goal of the project is to support the accelerated the adoption of vulnerability disclosure best practices including **bi-lateral safe harbor, readability for non-legal and non-native language audiences, and a recognizable mark of solidarity with the disclose.io movement.**
 
@@ -12,8 +12,8 @@ The goal of the project is to support the accelerated the adoption of vulnerabil
 
 1. Choose the [legal terms](/terms) that best fit your vulnerabilty disclosure or bug bounty progam.
 2. Add the appropriate [disclose.io logo](/logos) to your public program brief.
-3. Submit a pull request to your program to the open-source disclose.io [programs list](/programs-list).  
-4. Let the world know you're joining the movement! Here are some examples of others who have.
+3. Submit a pull request to your program to the open-source disclose.io [program list](/program-list).
+4. Let the world know you're joining the movement! Here are some [examples of others who have](/program-list/program-list.csv).
 4. Contribute back! We're looking for lawyers, hackers, and experts to collaborate. Check our [issues log](/issues).
 
 ## License


### PR DESCRIPTION
I noticed that the `programs-list` link was broken. I also made an assumption about where the link should point for the list of examples. That said, it feels a bit redundant, so perhaps we can just merge the 2 lines? 