### PR TITLE
Update README.md misspelled word and broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Driving simplicity, safety, and standardization in vulnerability disclosure.
 
-[disclose.io](https://disclose.io) is a collaborative and vendor-agnostic movement that engagements security researchers, corporate and independant legal experts, and industry leaders from all around the world.
+[disclose.io](https://disclose.io) is a collaborative and vendor-agnostic movement that engagements security researchers, corporate and independent legal experts, and industry leaders from all around the world.
 
 The goal of the project is to support the accelerated the adoption of vulnerability disclosure best practices including **bi-lateral safe harbor, readability for non-legal and non-native language audiences, and a recognizable mark of solidarity with the disclose.io movement.**
 


### PR DESCRIPTION
Hi,

I discovered a misspelled word and a broken link in need of updating on the following page:

disclose/README.md

"[disclose.io](https://disclose.io) is a collaborative and vendor-agnostic movement that engagements security researchers, corporate and independant legal experts, and industry leaders from all around the world.”

"independant” should read “independent”

And the “issues log” link in the following sentence leads to GitHub 404 page.

“5. Contribute back! We're looking for lawyers, hackers, and experts to collaborate. Check our issues log."

Broken link:

https://github.com/disclose/disclose/blob/master/issues

Thank you,

Peter