### PR TITLE
Update chase

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -1631,13 +1631,13 @@
   },
   {
     "program_name": "Chase",
-    "policy_url": "https://www.chase.com/digital/resources/privacy-security/security/vulnerability-disclosure",
-    "submission_url": "responsible.disclosure@jpmchase.com",
+    "policy_url": "https://responsibledisclosure.jpmorganchase.com/hc/en-us",
+    "submission_url": "https://responsibledisclosure.jpmorganchase.com/hc/en-us/requests/new",
     "launch_date": "",
     "bug_bounty": false,
     "swag": false,
     "hall_of_fame": false,
-    "safe_harbor": "partial"
+    "safe_harbor": ""
   },
   {
     "program_name": "Chaturbate",


### PR DESCRIPTION
Updates link to Chase (moved platform) and removes safe harbor, as Chase no longer has any safe harbor policy.