### PR TITLE
Downgrade Voatz Safe Harbor

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -8447,7 +8447,7 @@
     "bug_bounty": true,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": "partial"
+    "safe_harbor": "none"
   },
   {
     "program_name": "Vodafone",

--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -8447,7 +8447,7 @@
     "bug_bounty": true,
     "swag": false,
     "hall_of_fame": true,
-    "safe_harbor": "full"
+    "safe_harbor": "partial"
   },
   {
     "program_name": "Vodafone",


### PR DESCRIPTION
The Voatz safe harbor [has been modified](https://hackerone.com/voatz/policy_versions?change=3631417) and now no longer uses standard safe harbor language. In particular, the safe harbor makes several claims that weaken safe harbor provisions and make unclear the level of protection provided:

- Change of language from "will not initiate legal action against you" to "will not pursue civil action or initiate a complaint against you". This change of language to not initiating any legal action to only civil action leaves room for initiating criminal action, as has occurred in the West Virginia case.
- Change of language from "we will take steps to make it known that your actions were conducted in compliance with this policy" to "We will help to the extent we can" minimizes Voatz's role in protecting researchers when legal action is initiated by third parties.

As a result, I propose downgrading Voatz's safe harbor from "full" to "partial".