### PR TITLE
Update program-list.json

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -720,6 +720,16 @@
     "safe_harbor": ""
   },
   {
+    "program_name": "Athento",
+    "policy_url": "https://www.athento.com/bug-bounty-program-en/",
+    "submission_url": "support@athento.com",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": false,
+    "safe_harbor": "None"
+  },
+  {
     "program_name": "Atlassian",
     "policy_url": "https://bugcrowd.com/atlassian",
     "submission_url": "https://bugcrowd.com/atlassian/report",
@@ -4430,6 +4440,16 @@
     "safe_harbor": ""
   },
   {
+    "program_name": "LoginRadius",
+    "policy_url": "https://www.loginradius.com/bug-bounty/",
+    "submission_url": "security@loginradius.com",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": false,
+    "safe_harbor": "Partial"
+  },
+  {
     "program_name": "Loofah",
     "policy_url": "https://hackerone.com/loofah",
     "submission_url": "",
@@ -7340,6 +7360,16 @@
     "safe_harbor": ""
   },
   {
+    "program_name": "Spreaker",
+    "policy_url": "https://www.spreaker.com/security",
+    "submission_url": "security@spreaker.com",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": false,
+    "safe_harbor": "Partial"
+  },
+  {
     "program_name": "Sprout Social",
     "policy_url": "https://bugcrowd.com/sproutsocial",
     "submission_url": "https://bugcrowd.com/sproutsocial/report",
@@ -7438,6 +7468,16 @@
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": ""
+  },
+  {
+    "program_name": "StarLeaf",
+    "policy_url": "https://www.starleaf.com/c/bug-bounty-program/",
+    "submission_url": "bugbounty@starleaf.com",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": false,
+    "safe_harbor": "None"
   },
   {
     "program_name": "Starling Bank Limited",
@@ -7590,6 +7630,16 @@
     "safe_harbor": ""
   },
   {
+    "program_name": "Synology",
+    "policy_url": "https://www.synology.com/de-de/security/bounty_program#scope_and_reward",
+    "submission_url": "bounty@synology.com with https://www.synology.com/de-de/support/security_pgp_key",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": true,
+    "safe_harbor": "None"
+  },
+  {
     "program_name": "TD Ameritrade",
     "policy_url": "https://www.tdameritrade.com/security/security-vulnerability.page",
     "submission_url": "sirt@tdameritrade.com",
@@ -7668,6 +7718,16 @@
     "swag": false,
     "hall_of_fame": false,
     "safe_harbor": ""
+  },
+  {
+    "program_name": "TechGig",
+    "policy_url": "https://www.techgig.com/bugbounty",
+    "submission_url": "https://www.techgig.com/bugbounty#security-issue",
+    "launch_date": "",
+    "bug_bounty": false,
+    "swag": true,
+    "hall_of_fame": true,
+    "safe_harbor": "None"
   },
   {
     "program_name": "TechSmith",
@@ -8458,6 +8518,16 @@
     "swag": false,
     "hall_of_fame": true,
     "safe_harbor": "partial"
+  },
+  {
+    "program_name": "Vultr",
+    "policy_url": "https://www.vultr.com/bug-bounty/",
+    "submission_url": "https://www.vultr.com/bug-bounty/#report-issue",
+    "launch_date": "",
+    "bug_bounty": true,
+    "swag": false,
+    "hall_of_fame": false,
+    "safe_harbor": "None"
   },
   {
     "program_name": "Vyond",

--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -490,16 +490,6 @@
     "safe_harbor": ""
   },
   {
-    "program_name": "Ancientbrain",
-    "policy_url": "https://ancientbrain.com/bugs.php",
-    "submission_url": "bugs@ancientbrain.com",
-    "launch_date": "",
-    "bug_bounty": true,
-    "swag": false,
-    "hall_of_fame": false,
-    "safe_harbor": ""
-  },
-  {
     "program_name": "Android",
     "policy_url": "https://www.google.com/about/appsecurity/android-rewards/",
     "submission_url": "https://www.google.com/appserve/security-bugs/m2/new",


### PR DESCRIPTION
Added 7 new programs to program-list.json: Athento, LoginRadius, Spreaker, StarLeaf, Synology, TechGig, and Vultr. Six of them have a declared bug bounty program, while TechGig only has a Hall of Fame. 

I have a few doubts about LoginRadius's safe harbor field, and have chosen Partial to reflect these doubts.