### PR TITLE
Migrated schema to draft-06

### DIFF
--- a/program-list/program-list-schema.json
+++ b/program-list/program-list-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "type": "array",
   "items": [
     {


### PR DESCRIPTION
Aiming to solve the problem at #153. 
"Validate JSON" action uses ajv (https://github.com/epoberezkin/ajv) to... well... validate :P And looking at ajv issues I found out that the draft-04 schema is outdated, causing the error: "no schema with key or ref "http://json-schema.org/draft-04/schema#"" (https://github.com/epoberezkin/ajv/issues/472). So the solution here is migrate to draft-06 using a ajv command (https://github.com/jessedc/ajv-cli#migrate-schemas-to-draft-06).