### PR TITLE
Updated swagf to swag

### DIFF
--- a/program-list/program-list.json
+++ b/program-list/program-list.json
@@ -5,7 +5,7 @@
     "submission_url": "https://bugcrowd.com/isc2/report",
     "launch_date": "",
     "bug_bounty": false,
-    "swagf": false,
+    "swag": false,
     "hall_of_fame": true,
     "safe_harbor": "partial"
   },


### PR DESCRIPTION
Corrects ISC2 swag key to be `swag` (previously `swagf` in error)