### PR TITLE
Update Whatbox program to remove bug bounty rewards

### DIFF
--- a/program-list.json
+++ b/program-list.json
@@ -21555,7 +21555,7 @@
       "program_name": "Whatbox",
       "policy_url": "https://whatbox.ca/policies/security",
       "launch_date": "2013-12-03",
-      "offers_bounty": "yes",
+      "offers_bounty": "no",
       "offers_swag": false,
       "hall_of_fame": "https://whatbox.ca/policies/security/hall_of_fame",
       "safe_harbor": "full",


### PR DESCRIPTION
# Summary

Remove Whatbox program bug bounty rewards

While LLMs are discovering critical issues all over the open source ecosystem, in our bug bounty program LLMs have only grown the volume of invalid, unverified and irrelevant reports we receive.

With us now receiving hundreds of invalid reports per week and the invalid rate exceeding 97% (and the few valid issues all being exceeding low priority) we are cutting all bug bounty rewards in hopes of salvaging any value still left in bug bounty submissions.

# Quality Assurance Checklist

| Review Items                            | Y/N |
|-----------------------------------------|-----|
| Site has a publicly known bug bounty or vulnerability disclosure program    |  Y  |
| Disclosure policy is publicly available |  Y  |
| Public URL                              |  Y  |
| Submission follows the [Diodb schema](https://github.com/disclose/diodb/blob/master/program-list-schema.json)     |   Y |

Your Twitter handle (Optional): 
